### PR TITLE
Remove rumors, add jrandoms AWOL announcement link

### DIFF
--- a/_posts/2018-03-15-introduction-to-i2p.md
+++ b/_posts/2018-03-15-introduction-to-i2p.md
@@ -151,13 +151,10 @@ effort to better the tool. The vast majority of these users appear to be taking
 their privacy very serious and many of them work under pseudonym. The original
 creator was known as 'jrandom' which is a generic term used in many books to
 denote the user. Development began in 2003 and started around the same time
-that Tor development began. At some point, jrandom vanished and the entire
-project very nearly came to a crashing halt. Over time, it was salvaged and the
+that Tor development began. At some point, jrandom vanished, see [jrandom's AWOL Announcement](https://geti2p.net/en/misc/jrandom-awol)
+and the entire project very nearly came to a crashing halt. Over time, it was salvaged and the
 I2P project was able to continue development.
 
-Unsubstantiated claims that jrandom was a Chinese national now being held in a
-prison in mainland China have been made but no facts available currently back
-up these claims. An interesting rumor none the less. 
 
 ## What does I2P do
 


### PR DESCRIPTION
I think the rumor is unnecessary and not worth talking about, besides that jrandom left a signed message where he told anyone that he is going to leave 
https://geti2p.net/en/misc/jrandom-awol
Great job on everything else :)